### PR TITLE
Take 2: refactor to allow swappable layer selection methods

### DIFF
--- a/src/napari_matplotlib/base.py
+++ b/src/napari_matplotlib/base.py
@@ -11,6 +11,7 @@ from matplotlib.backends.backend_qt5agg import (
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QVBoxLayout, QWidget
 
+from .layer_selectors import LayerListSelector
 from .util import Interval
 
 mpl.rc("axes", edgecolor="white")
@@ -66,13 +67,22 @@ class NapariMPLWidget(QWidget):
         self.layout().addWidget(self.toolbar)
         self.layout().addWidget(self.canvas)
 
+        # set up the selector
+        self.layer_selector = LayerListSelector(
+            viewer=napari_viewer, parent_widget=self
+        )
+
         self.setup_callbacks()
-        self.layers: List[napari.layers.Layer] = []
+        # self.layers: List[napari.layers.Layer] = []
 
     # Accept any number of input layers by default
     n_layers_input = Interval(None, None)
     # Accept any type of input layer by default
     input_layer_types: Tuple[napari.layers.Layer, ...] = (napari.layers.Layer,)
+
+    @property
+    def layers(self) -> List[napari.layers.Layer]:
+        return self.layer_selector.selected_layers
 
     @property
     def n_selected_layers(self) -> int:
@@ -97,13 +107,13 @@ class NapariMPLWidget(QWidget):
         # z-step changed in viewer
         self.viewer.dims.events.current_step.connect(self._draw)
         # Layer selection changed in viewer
-        self.viewer.layers.selection.events.changed.connect(self.update_layers)
+        # self.viewer.layers.selection.events.changed.connect(self.update_layers)
 
     def update_layers(self, event: napari.utils.events.Event) -> None:
         """
         Update the layers attribute with currently selected layers and re-draw.
         """
-        self.layers = list(self.viewer.layers.selection)
+        # self.layers = list(self.viewer.layers.selection)
         self._on_update_layers()
         self._draw()
 

--- a/src/napari_matplotlib/histogram.py
+++ b/src/napari_matplotlib/histogram.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from .base import NapariMPLWidget
+from .layer_selectors import LayerListSelector, LayerSelector
 
 __all__ = ["HistogramWidget"]
 
@@ -19,8 +20,12 @@ class HistogramWidget(NapariMPLWidget):
     n_layers_input = Interval(1, 1)
     input_layer_types = (napari.layers.Image,)
 
-    def __init__(self, napari_viewer: napari.viewer.Viewer):
-        super().__init__(napari_viewer)
+    def __init__(
+        self,
+        napari_viewer: napari.viewer.Viewer,
+        layer_selector: LayerSelector = LayerListSelector,
+    ):
+        super().__init__(napari_viewer, layer_selector)
         self.axes = self.canvas.figure.subplots()
         self.update_layers(None)
 

--- a/src/napari_matplotlib/layer_selectors.py
+++ b/src/napari_matplotlib/layer_selectors.py
@@ -1,0 +1,19 @@
+from typing import List
+
+import napari
+from qtpy.QtWidgets import QWidget
+
+
+class LayerListSelector:
+    def __init__(self, viewer: napari.Viewer, parent_widget: QWidget):
+        self.viewer = viewer
+        self.viewer.layers.selection.events.changed.connect(self.update_layers)
+
+        self.update_layers()
+
+    def update_layers(self, event=None):
+        self._selected_layers = list(self.viewer.layers.selection)
+
+    @property
+    def selected_layers(self) -> List[napari.layers.Layer]:
+        return self._selected_layers

--- a/src/napari_matplotlib/layer_selectors.py
+++ b/src/napari_matplotlib/layer_selectors.py
@@ -7,7 +7,7 @@ from napari.utils.events.event import EmitterGroup, Event
 from qtpy.QtWidgets import QWidget
 
 
-class BaseLayerSelector:
+class BaseLayerSelector(abc.ABC):
     """Base class for creating layer selectors.
 
     Layer selectors provide the interactive elements for selecting which
@@ -119,20 +119,18 @@ class LayerWidgetSelector(BaseLayerSelector):
         ]
 
 
-def get_layer_selector(
-    selector: Union[str, BaseLayerSelector]
-) -> BaseLayerSelector:
+# Type for annotating variables that accept all layer selectors
+LayerSelector = Union[Type[LayerListSelector], Type[LayerWidgetSelector]]
+
+
+def get_layer_selector(selector: Union[str, LayerSelector]) -> LayerSelector:
     if isinstance(selector, str):
         return globals()[selector]
 
-    elif isinstance(selector, BaseLayerSelector):
+    elif issubclass(selector, BaseLayerSelector):
         # passthrough if already a LayerSelector
         return selector
     else:
         raise TypeError(
             "selector should be a string or LayerSelector subclass"
         )
-
-
-# Type for annotating variables that accept all layer selectors
-LayerSelector = Union[Type[LayerListSelector], Type[LayerWidgetSelector]]

--- a/src/napari_matplotlib/layer_selectors.py
+++ b/src/napari_matplotlib/layer_selectors.py
@@ -7,7 +7,28 @@ from napari.utils.events.event import EmitterGroup, Event
 from qtpy.QtWidgets import QWidget
 
 
-class BaseLayerSelector(abc.ABC):
+class BaseLayerSelector:
+    """Base class for creating layer selectors.
+
+    Layer selectors provide the interactive elements for selecting which
+    layer(s) to plot from.
+
+    To satisfy the API, layer selectors must take the following arguments
+        napari_viewer : napari.Viewer
+            The napari viewer from which to select layers from.
+        parent_widget : QWidget
+            The widget to which any GUI elements will be added.
+        valid_layer_types : Tuple[napari.layers.Layer, ...]
+            A tuple of the napari layer types the layer selector can select
+
+    Further, the layer selector most have a `selected_layers` property that
+    returns the list of currently selected layers.
+
+    To allow actions to be performed when the selectino changes, the base class
+    has a `LayerSelector.events.selected_layers()` event that can be connected
+    to.
+    """
+
     def __init__(
         self,
         napari_viewer: napari.Viewer,

--- a/src/napari_matplotlib/layer_selectors.py
+++ b/src/napari_matplotlib/layer_selectors.py
@@ -1,19 +1,40 @@
-from typing import List
+from typing import List, Protocol, Union
 
 import napari
 from qtpy.QtWidgets import QWidget
+from typing_extensions import runtime_checkable
 
 
-class LayerListSelector:
+@runtime_checkable
+class LayerSelector(Protocol):
+    @property
+    def selected_layers(self) -> List[napari.layers.Layer]:
+        ...
+
+
+class LayerListSelector(LayerSelector):
     def __init__(self, viewer: napari.Viewer, parent_widget: QWidget):
         self.viewer = viewer
         self.viewer.layers.selection.events.changed.connect(self.update_layers)
 
         self.update_layers()
 
-    def update_layers(self, event=None):
+    def update_layers(self, event: napari.utils.events.Event = None) -> None:
         self._selected_layers = list(self.viewer.layers.selection)
 
     @property
     def selected_layers(self) -> List[napari.layers.Layer]:
         return self._selected_layers
+
+
+def get_layer_selector(selector: Union[str, LayerSelector]) -> LayerSelector:
+    if isinstance(selector, str):
+        return globals()[selector]
+
+    elif isinstance(selector, LayerSelector):
+        # passthrough if already a LayerSelector
+        return selector
+    else:
+        raise TypeError(
+            "selector should be a string or LayerSelector subclass"
+        )

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -7,6 +7,7 @@ from magicgui import magicgui
 from magicgui.widgets import ComboBox
 
 from .base import NapariMPLWidget
+from .layer_selectors import LayerListSelector, LayerSelector
 from .util import Interval
 
 __all__ = ["ScatterWidget", "FeaturesScatterWidget"]
@@ -24,8 +25,12 @@ class ScatterBaseWidget(NapariMPLWidget):
     # the scatter is plotted as a 2dhist
     _threshold_to_switch_to_histogram = 500
 
-    def __init__(self, napari_viewer: napari.viewer.Viewer):
-        super().__init__(napari_viewer)
+    def __init__(
+        self,
+        napari_viewer: napari.viewer.Viewer,
+        layer_selector: LayerSelector = LayerListSelector,
+    ):
+        super().__init__(napari_viewer, layer_selector)
 
         self.axes = self.canvas.figure.subplots()
         self.update_layers(None)
@@ -119,8 +124,12 @@ class FeaturesScatterWidget(ScatterBaseWidget):
         napari.layers.Vectors,
     )
 
-    def __init__(self, napari_viewer: napari.viewer.Viewer):
-        super().__init__(napari_viewer)
+    def __init__(
+        self,
+        napari_viewer: napari.viewer.Viewer,
+        layer_selector: LayerSelector = LayerListSelector,
+    ):
+        super().__init__(napari_viewer, layer_selector)
         self._key_selection_widget = magicgui(
             self._set_axis_keys,
             x_axis_key={"choices": self._get_valid_axis_keys},

--- a/src/napari_matplotlib/slice.py
+++ b/src/napari_matplotlib/slice.py
@@ -5,6 +5,7 @@ import numpy as np
 from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel, QSpinBox
 
 from .base import NapariMPLWidget
+from .layer_selectors import LayerListSelector, LayerSelector
 from .util import Interval
 
 __all__ = ["SliceWidget"]
@@ -21,9 +22,13 @@ class SliceWidget(NapariMPLWidget):
     n_layers_input = Interval(1, 1)
     input_layer_types = (napari.layers.Image,)
 
-    def __init__(self, napari_viewer: napari.viewer.Viewer):
+    def __init__(
+        self,
+        napari_viewer: napari.viewer.Viewer,
+        layer_selector: LayerSelector = LayerListSelector,
+    ):
         # Setup figure/axes
-        super().__init__(napari_viewer)
+        super().__init__(napari_viewer, layer_selector)
         self.axes = self.canvas.figure.subplots()
 
         button_layout = QHBoxLayout()

--- a/src/napari_matplotlib/tests/test_layer_selectors.py
+++ b/src/napari_matplotlib/tests/test_layer_selectors.py
@@ -1,0 +1,23 @@
+import pytest
+
+from napari_matplotlib.layer_selectors import (
+    LayerListSelector,
+    get_layer_selector,
+)
+
+
+def test_get_layer_selector_string():
+    selector = get_layer_selector("LayerListSelector")
+
+    assert selector is LayerListSelector
+
+
+def test_get_layer_selector_object():
+    selector = get_layer_selector(LayerListSelector)
+
+    assert selector is LayerListSelector
+
+
+def test_get_layer_selector_invalid():
+    with pytest.raises(TypeError):
+        _ = get_layer_selector(5)


### PR DESCRIPTION
This PR separates the layer selection code from the canvas base class (``) by defining a new base class called `BaseLayerSelector`. The `BaseLayerSelector` is a base class that defines the API for custom layer selection code. As an example, I have created a new layer selector `LayerWidgetSelector` that allows the user to select the layer to plot from via a combobox. 

This is not a breaking change, as the default values are for selecting via the layer list (the current behavior on `main`).

To do:
- [ ] add tests
- [ ] generalize the `LayerWidgetSelector` to create as many comboboxes as requested by `n_layers_input`.

This PR supercedes #51.