### PR TITLE
Improve mypy type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
     rev: v1.2.0
     hooks:
      - id: mypy
-       args: ["--disallow-incomplete-defs", "--ignore-missing-imports"]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,24 @@ fix = true
 convention = "numpy"
 
 [tool.mypy]
+# Block below are checks that form part of mypy 'strict' mode
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_equality = true
+strict_concatenate = true
+check_untyped_defs = true
+disallow_subclassing_any = false # TODO: fix
+disallow_untyped_decorators = true
+disallow_any_generics = true
+disallow_untyped_calls = true
 disallow_incomplete_defs = true
-ignore_missing_imports = true
+disallow_untyped_defs = true
+no_implicit_reexport = true
+warn_return_any = false # TODO: fix
+
+[[tool.mypy.overrides]]
+module = [
+    "napari_matplotlib/tests/*",
+]
+disallow_untyped_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,7 @@ fix = true
 
 [tool.ruff.pydocstyle]
 convention = "numpy"
+
+[tool.mypy]
+disallow_incomplete_defs = true
+ignore_missing_imports = true

--- a/src/napari_matplotlib/base.py
+++ b/src/napari_matplotlib/base.py
@@ -125,7 +125,7 @@ class NapariMPLWidget(QWidget):
         This is a no-op, and is intended for derived classes to override.
         """
 
-    def apply_napari_colorscheme(self):
+    def apply_napari_colorscheme(self) -> None:
         """Apply napari-compatible colorscheme to the axes object."""
         if self.axes is None:
             return
@@ -153,7 +153,7 @@ class NapariMPLWidget(QWidget):
         This is a no-op, and is intended for derived classes to override.
         """
 
-    def _replace_toolbar_icons(self):
+    def _replace_toolbar_icons(self) -> None:
         # Modify toolbar icons and some tooltips
         for action in self.toolbar.actions():
             text = action.text()
@@ -175,7 +175,7 @@ class NapariMPLWidget(QWidget):
 class NapariNavigationToolbar(NavigationToolbar2QT):
     """Custom Toolbar style for Napari."""
 
-    def _update_buttons_checked(self):
+    def _update_buttons_checked(self) -> None:
         """Update toggle tool icons when selected/unselected."""
         super()._update_buttons_checked()
         # changes pan/zoom icons depending on state (checked or not)

--- a/src/napari_matplotlib/slice.py
+++ b/src/napari_matplotlib/slice.py
@@ -49,7 +49,7 @@ class SliceWidget(NapariMPLWidget):
         self.update_layers(None)
 
     @property
-    def layer(self):
+    def layer(self) -> napari.layers.Layer:
         """
         Layer being plotted.
         """

--- a/src/napari_matplotlib/tests/test_scatter.py
+++ b/src/napari_matplotlib/tests/test_scatter.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, Tuple
+
 import numpy as np
 
 from napari_matplotlib import FeaturesScatterWidget, ScatterWidget
@@ -19,7 +21,9 @@ def test_features_scatter_widget(make_napari_viewer):
     FeaturesScatterWidget(viewer)
 
 
-def make_labels_layer_with_features():
+def make_labels_layer_with_features() -> (
+    Tuple[np.ndarray, Dict[str, Tuple[Any]]]
+):
     label_image = np.zeros((100, 100), dtype=np.uint16)
     for label_value, start_index in enumerate([10, 30, 50], start=1):
         end_index = start_index + 10

--- a/src/napari_matplotlib/tests/test_util.py
+++ b/src/napari_matplotlib/tests/test_util.py
@@ -12,4 +12,4 @@ def test_interval():
     assert 10 not in interval
 
     with pytest.raises(ValueError, match="must be an integer"):
-        "string" in interval
+        "string" in interval  # type: ignore


### PR DESCRIPTION
This turns on most of the recommended `mypy` checks, and fixes a few things. There are two options that I've disabled in the config that I think would be more effor than they're worth to fix, because they involve interactions with stuff we're importing from outside packages that have incomplete typing.

Fixes https://github.com/matplotlib/napari-matplotlib/issues/81