### PR TITLE
Add doc hosting on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,5 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  apt_packages:
+    - qtbase5-dev

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,3 +13,4 @@ build:
     python: "3.10"
   apt_packages:
     - qtbase5-dev
+    - xvfb

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,5 +12,4 @@ build:
   tools:
     python: "3.10"
   apt_packages:
-    - qtbase5-dev
     - xvfb

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ qtgallery_conf = {
 }
 
 numpydoc_show_class_members = False
+automodapi_inheritance_diagram = False
 
 intersphinx_mapping = {
     "napari": ("https://napari.org/", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,13 @@ sphinx_gallery_conf = {
     "reset_modules": (qtgallery.reset_qapp,),
 }
 
+qtgallery_conf = {
+    "xvfb_size": (640, 480),
+    "xvfb_color_depth": 24,
+    "xfvb_use_xauth": False,
+    "xfvb_extra_args": [],
+}
+
 numpydoc_show_class_members = False
 
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-import qtgallery
+# import qtgallery
 
 # -- Project information -----------------------------------------------------
 
@@ -30,7 +30,7 @@ author = "David Stansby"
 extensions = [
     "numpydoc",
     "sphinx_gallery.gen_gallery",
-    "qtgallery",
+    # "qtgallery",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
     "sphinx.ext.intersphinx",
@@ -40,16 +40,17 @@ sphinx_gallery_conf = {
     # Don't run any gallery examples, because they're not working on
     # readthedocs at the moment
     "filename_pattern": "a^",
-    "image_scrapers": (qtgallery.qtscraper,),
-    "reset_modules": (qtgallery.reset_qapp,),
+    # "image_scrapers": (qtgallery.qtscraper,),
+    # "reset_modules": (qtgallery.reset_qapp,),
 }
 
-qtgallery_conf = {
-    "xvfb_size": (640, 480),
-    "xvfb_color_depth": 24,
-    "xfvb_use_xauth": False,
-    "xfvb_extra_args": [],
-}
+
+# qtgallery_conf = {
+#     "xvfb_size": (640, 480),
+#     "xvfb_color_depth": 24,
+#     "xfvb_use_xauth": False,
+#     "xfvb_extra_args": [],
+# }
 
 numpydoc_show_class_members = False
 automodapi_inheritance_diagram = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,9 @@ extensions = [
 ]
 
 sphinx_gallery_conf = {
-    "filename_pattern": ".",
+    # Don't run any gallery examples, because they're not working on
+    # readthedocs at the moment
+    "filename_pattern": "a^",
     "image_scrapers": (qtgallery.qtscraper,),
     "reset_modules": (qtgallery.reset_qapp,),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ author = "David Stansby"
 extensions = [
     "numpydoc",
     "sphinx_gallery.gen_gallery",
+    "qtgallery",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
     "sphinx.ext.intersphinx",

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ docs =
     napari[all]
     numpydoc
     pydata-sphinx-theme
-    qtgallery
     sphinx
     sphinx-automodapi
     sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ napari.manifest =
 
 [options.extras_require]
 docs =
+    napari[all]
     numpydoc
     pydata-sphinx-theme
     qtgallery


### PR DESCRIPTION
Fixes https://github.com/matplotlib/napari-matplotlib/issues/18. This is a minimal config to get the docs building and hosted. The gallery build is disabled becaus I can't get it to work, but I think it's worth merging this as is so we can work on fixing the gallery and improving the rest of the docs in parallel.