### PR TITLE
dstansby → matplotlib in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # napari-matplotlib
 
-[![License](https://img.shields.io/pypi/l/napari-matplotlib.svg?color=green)](https://github.com/dstansby/napari-matplotlib/raw/main/LICENSE)
+[![License](https://img.shields.io/pypi/l/napari-matplotlib.svg?color=green)](https://github.com/matplotlib/napari-matplotlib/raw/main/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/napari-matplotlib.svg?color=green)](https://pypi.org/project/napari-matplotlib)
 [![Python Version](https://img.shields.io/pypi/pyversions/napari-matplotlib.svg?color=green)](https://python.org)
-[![tests](https://github.com/dstansby/napari-matplotlib/workflows/tests/badge.svg)](https://github.com/dstansby/napari-matplotlib/actions)
-[![codecov](https://codecov.io/gh/dstansby/napari-matplotlib/branch/main/graph/badge.svg)](https://codecov.io/gh/dstansby/napari-matplotlib)
+[![tests](https://github.com/matplotlib/napari-matplotlib/workflows/tests/badge.svg)](https://github.com/matplotlib/napari-matplotlib/actions)
+[![codecov](https://codecov.io/gh/matplotlib/napari-matplotlib/branch/main/graph/badge.svg)](https://codecov.io/gh/matplotlib/napari-matplotlib)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/matplotlib/pytest-mpl/master.svg)](https://results.pre-commit.ci/latest/github/matplotlib/pytest-mpl/master)
 [![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/napari-matplotlib)](https://napari-hub.org/plugins/napari-matplotlib)
 
@@ -19,15 +19,15 @@ A plugin to create Matplotlib plots from napari layers
 
 ### `Slice`
 Plots 1D slices of data along a specified axis.
-![](https://raw.githubusercontent.com/dstansby/napari-matplotlib/main/examples/slice.png)
+![](https://raw.githubusercontent.com/matplotlib/napari-matplotlib/main/examples/slice.png)
 
 ### `Histogram`
 Plots histograms of individual image layers, or RGB histograms of an RGB image
-![](https://raw.githubusercontent.com/dstansby/napari-matplotlib/main/examples/hist.png)
+![](https://raw.githubusercontent.com/matplotlib/napari-matplotlib/main/examples/hist.png)
 
 ### `Scatter`
 Scatters the values of two similarly sized images layers against each other.
-![](https://raw.githubusercontent.com/dstansby/napari-matplotlib/main/examples/scatter.png)
+![](https://raw.githubusercontent.com/matplotlib/napari-matplotlib/main/examples/scatter.png)
 
 ## Installation
 
@@ -39,7 +39,7 @@ You can install `napari-matplotlib` via [pip]:
 
 To install latest development version :
 
-    pip install git+https://github.com/dstansby/napari-matplotlib.git
+    pip install git+https://github.com/matplotlib/napari-matplotlib.git
 
 
 ## Contributing


### PR DESCRIPTION
dstansby → matplotlib
Has the effect of fixing the tests badge. But might as well update everything whilst I'm here.