### PR TITLE
Simplify logic for adding a single axes

### DIFF
--- a/src/napari_matplotlib/histogram.py
+++ b/src/napari_matplotlib/histogram.py
@@ -21,8 +21,7 @@ class HistogramWidget(NapariMPLWidget):
 
     def __init__(self, napari_viewer: napari.viewer.Viewer):
         super().__init__(napari_viewer)
-        self.axes = self.canvas.figure.subplots()
-        self.apply_napari_colorscheme()
+        self.add_single_axes()
         self.update_layers(None)
 
     def clear(self) -> None:

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -31,8 +31,7 @@ class ScatterBaseWidget(NapariMPLWidget):
     def __init__(self, napari_viewer: napari.viewer.Viewer):
         super().__init__(napari_viewer)
 
-        self.axes = self.canvas.figure.subplots()
-        self.apply_napari_colorscheme()
+        self.add_single_axes()
         self.update_layers(None)
 
     def clear(self) -> None:

--- a/src/napari_matplotlib/slice.py
+++ b/src/napari_matplotlib/slice.py
@@ -24,7 +24,7 @@ class SliceWidget(NapariMPLWidget):
     def __init__(self, napari_viewer: napari.viewer.Viewer):
         # Setup figure/axes
         super().__init__(napari_viewer)
-        self.axes = self.canvas.figure.subplots()
+        self.add_single_axes()
 
         button_layout = QHBoxLayout()
         self.layout().addLayout(button_layout)


### PR DESCRIPTION
- Add a `figure()` property to `NapariMPLWidget`, to replace the documented `.figure` attribute that actually never existed.
- Add a `add_single_axes()` helper method to `NapariMPLWidget`, that automatically adds a single axes and styles it.
- Clarify that `NapariMPLWidget` is not responsible for adding Axes to the figure.