### PR TITLE
Don't autofix PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,6 @@ repos:
     rev: 'v0.0.264'
     hooks:
       - id: ruff
+
+ci:
+  autofix_prs: false


### PR DESCRIPTION
I find this annoying, so unless anyone has any objections I think we should turn off `pre-commit.ci` autofixing our PRs.