### PR TITLE
Added qt_api in pytest.ini and commented out error in filterwarnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
+qt_api=pyqt5
 filterwarnings =
-    error
+    #error
 
     # Coming from vispy
     ignore:distutils Version classes are deprecated:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
 qt_api=pyqt5
 filterwarnings =
-    #error
+    error
 
     # Coming from vispy
     ignore:distutils Version classes are deprecated:DeprecationWarning
+    ignore:`np.bool8` is a deprecated alias for `np.bool_`:DeprecationWarning


### PR DESCRIPTION
Had to pip install pytest-qtbot and then set the qt_api=pyqt5 for the tests to work as indeed
Also commenting out error in filterwarnings was necessary.