### PR TITLE
Make icon size the same as `QtViewerPushButton` for UI consistency.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     matplotlib
     napari
     numpy
+    tinycss2
 python_requires = >=3.8
 include_package_data = True
 package_dir =
@@ -57,6 +58,7 @@ testing =
     pyqt6
     pytest
     pytest-cov
+    pytest-mock
     pytest-mpl
     pytest-qt
     tox

--- a/src/napari_matplotlib/base.py
+++ b/src/napari_matplotlib/base.py
@@ -12,7 +12,7 @@ from matplotlib.figure import Figure
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QVBoxLayout, QWidget
 
-from .util import Interval
+from .util import Interval, from_css_get_size_of
 
 # Icons modified from
 # https://github.com/matplotlib/matplotlib/tree/main/lib/matplotlib/mpl-data/images
@@ -52,7 +52,9 @@ class NapariMPLWidget(QWidget):
 
         self.canvas.figure.patch.set_facecolor("none")
         self.canvas.figure.set_layout_engine("constrained")
-        self.toolbar = NapariNavigationToolbar(self.canvas, self)
+        self.toolbar = NapariNavigationToolbar(
+            self.canvas, self
+        )  # type: ignore[no-untyped-call]
         self._replace_toolbar_icons()
 
         self.setLayout(QVBoxLayout())
@@ -188,6 +190,12 @@ class NapariMPLWidget(QWidget):
 
 class NapariNavigationToolbar(NavigationToolbar2QT):
     """Custom Toolbar style for Napari."""
+
+    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        super().__init__(*args, **kwargs)
+        self.setIconSize(
+            from_css_get_size_of("QtViewerPushButton", fallback=(28, 28))
+        )
 
     def _update_buttons_checked(self) -> None:
         """Update toggle tool icons when selected/unselected."""

--- a/src/napari_matplotlib/tests/test_util.py
+++ b/src/napari_matplotlib/tests/test_util.py
@@ -1,6 +1,7 @@
 import pytest
+from qtpy.QtCore import QSize
 
-from napari_matplotlib.util import Interval
+from napari_matplotlib.util import Interval, from_css_get_size_of
 
 
 def test_interval():
@@ -13,3 +14,18 @@ def test_interval():
 
     with pytest.raises(ValueError, match="must be an integer"):
         "string" in interval  # type: ignore
+
+
+def test_get_size_from_css(mocker):
+    """Test getting the max-width and max-height from something in css"""
+    test_css = """
+        Flibble {
+            min-width : 0;
+            max-width : 123px;
+            min-height : 0px;
+            max-height : 456px;
+            padding: 0px;
+        }
+        """
+    mocker.patch("napari.qt.get_current_stylesheet").return_value = test_css
+    assert from_css_get_size_of("Flibble", (1, 1)) == QSize(123, 456)

--- a/src/napari_matplotlib/util.py
+++ b/src/napari_matplotlib/util.py
@@ -1,4 +1,8 @@
-from typing import Optional
+from typing import List, Optional, Tuple, Union
+
+import napari.qt
+import tinycss2
+from qtpy.QtCore import QSize
 
 
 class Interval:
@@ -34,3 +38,60 @@ class Interval:
         if self.upper is not None and val > self.upper:
             return False
         return True
+
+
+def _has_id(nodes: List[tinycss2.ast.Node], id_name: str) -> bool:
+    """
+    Is `id_name` in IdentTokens in the list of CSS `nodes`?
+    """
+    return any(
+        [node.type == "ident" and node.value == id_name for node in nodes]
+    )
+
+
+def _get_dimension(
+    nodes: List[tinycss2.ast.Node], id_name: str
+) -> Union[int, None]:
+    """
+    Get the value of the DimensionToken for the IdentToken `id_name`.
+
+    Returns
+    -------
+        None if no IdentToken is found.
+    """
+    cleaned_nodes = [node for node in nodes if node.type != "whitespace"]
+    for name, _, value, _ in zip(*(iter(cleaned_nodes),) * 4):
+        if (
+            name.type == "ident"
+            and value.type == "dimension"
+            and name.value == id_name
+        ):
+            return value.int_value
+    return None
+
+
+def from_css_get_size_of(
+    qt_element_name: str, fallback: Tuple[int, int]
+) -> QSize:
+    """
+    Get the size of `qt_element_name` from napari's current stylesheet.
+
+    TODO: Confirm that the napari.qt.get_current_stylesheet changes with napari
+          theme (docs seem to indicate it should)
+
+    Returns
+    -------
+        QSize of the element if it's found, the `fallback` if it's not found..
+    """
+    rules = tinycss2.parse_stylesheet(
+        napari.qt.get_current_stylesheet(),
+        skip_comments=True,
+        skip_whitespace=True,
+    )
+    w, h = None, None
+    for rule in rules:
+        if _has_id(rule.prelude, qt_element_name):
+            w = _get_dimension(rule.content, "max-width")
+            h = _get_dimension(rule.content, "max-height")
+            return QSize(w, h)
+    return QSize(*fallback)


### PR DESCRIPTION
Solves #46 (with rather a lot of code).

## Summary

Introduce a dependency on [tinycss2](https://courtbouillon.org/tinycss2). Then _use_ it via some ...err... "convenience" parsing functions. Hopefully, these are clear and somewhat reusable for our eventual solution of #86. 

## Testing

Added a unit test for my function. Open to adding test cases if anyone thinks of one.

## Reviewer notes:

The other ways to solve #46  is via a regex (~5 LoC) or via `thing.setIconSize(QSize(28, 28))` (2 LoC). Compare those with this @ ~30 LoC. 🙃 

### Argument for doing it this way

Boils down to #86. We should be able to parse other colours from the "current" CSS file with these functions. Then do an internal update of the axes colours etc (currently most of the code in `NapariMPLWidget.apply_napari_colorscheme`). And I _think_ our update code could be connected to `viewer.events.theme` ([undocumented](https://napari.org/stable/guides/events_reference.html#viewer-events)... we can probably test quite easily and fix the docs upstream either way).

### Against

I'm actually increasingly open to a regex solution. [It's what napari themselves seem to do](https://github.com/napari/napari/blob/d8dd1d2f592618064d2b5ac0c770ac1eb4741e77/napari/utils/theme.py#L98-L101). Opinions gratefully received.

------

Also if anyone knows of a better way to customise my subclass's constructor whilst keeping the type checker happy. Like maybe there's a better design decision. Discussion of interest...

* https://github.com/python/typing/discussions/1079