### PR TITLE
Fix leaky QT widgets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ fix = true
 convention = "numpy"
 
 [tool.mypy]
+python_version = "3.8"
 # Block below are checks that form part of mypy 'strict' mode
 warn_unused_configs = true
 warn_redundant_casts = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ disallow_incomplete_defs = true
 disallow_untyped_defs = true
 no_implicit_reexport = true
 warn_return_any = false # TODO: fix
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/src/napari_matplotlib/base.py
+++ b/src/napari_matplotlib/base.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import napari
 from matplotlib.axes import Axes
@@ -43,8 +43,12 @@ class NapariMPLWidget(QWidget):
         List of currently selected napari layers.
     """
 
-    def __init__(self, napari_viewer: napari.viewer.Viewer):
-        super().__init__()
+    def __init__(
+        self,
+        napari_viewer: napari.viewer.Viewer,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent=parent)
 
         self.viewer = napari_viewer
         self.canvas = FigureCanvas()
@@ -52,7 +56,7 @@ class NapariMPLWidget(QWidget):
         self.canvas.figure.patch.set_facecolor("none")
         self.canvas.figure.set_layout_engine("constrained")
         self.toolbar = NapariNavigationToolbar(
-            self.canvas, self
+            self.canvas, parent=self
         )  # type: ignore[no-untyped-call]
         self._replace_toolbar_icons()
 

--- a/src/napari_matplotlib/histogram.py
+++ b/src/napari_matplotlib/histogram.py
@@ -1,12 +1,13 @@
-import numpy as np
-
-from .base import NapariMPLWidget
-
-__all__ = ["HistogramWidget"]
+from typing import Optional
 
 import napari
+import numpy as np
+from qtpy.QtWidgets import QWidget
 
+from .base import NapariMPLWidget
 from .util import Interval
+
+__all__ = ["HistogramWidget"]
 
 _COLORS = {"r": "tab:red", "g": "tab:green", "b": "tab:blue"}
 
@@ -19,8 +20,12 @@ class HistogramWidget(NapariMPLWidget):
     n_layers_input = Interval(1, 1)
     input_layer_types = (napari.layers.Image,)
 
-    def __init__(self, napari_viewer: napari.viewer.Viewer):
-        super().__init__(napari_viewer)
+    def __init__(
+        self,
+        napari_viewer: napari.viewer.Viewer,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(napari_viewer, parent=parent)
         self.add_single_axes()
         self.update_layers(None)
 

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -4,6 +4,7 @@ import napari
 import numpy.typing as npt
 from magicgui import magicgui
 from magicgui.widgets import ComboBox
+from qtpy.QtWidgets import QWidget
 
 from .base import NapariMPLWidget
 from .util import Interval
@@ -20,8 +21,12 @@ class ScatterBaseWidget(NapariMPLWidget):
     # the scatter is plotted as a 2D histogram
     _threshold_to_switch_to_histogram = 500
 
-    def __init__(self, napari_viewer: napari.viewer.Viewer):
-        super().__init__(napari_viewer)
+    def __init__(
+        self,
+        napari_viewer: napari.viewer.Viewer,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(napari_viewer, parent=parent)
 
         self.add_single_axes()
         self.update_layers(None)
@@ -113,16 +118,21 @@ class FeaturesScatterWidget(ScatterBaseWidget):
         napari.layers.Vectors,
     )
 
-    def __init__(self, napari_viewer: napari.viewer.Viewer):
-        super().__init__(napari_viewer)
-        self._key_selection_widget = magicgui(
+    def __init__(
+        self,
+        napari_viewer: napari.viewer.Viewer,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(napari_viewer, parent=parent)
+        self._key_selection_function_gui = magicgui(
             self._set_axis_keys,
             x_axis_key={"choices": self._get_valid_axis_keys},
             y_axis_key={"choices": self._get_valid_axis_keys},
             call_button="plot",
         )
-
-        self.layout().addWidget(self._key_selection_widget.native)
+        _key_selection_widget = self._key_selection_function_gui.native
+        _key_selection_widget.setParent(self)
+        self.layout().addWidget(_key_selection_widget)
 
     @property
     def x_axis_key(self) -> Optional[str]:
@@ -231,7 +241,7 @@ class FeaturesScatterWidget(ScatterBaseWidget):
         Called when the layer selection changes by ``self.update_layers()``.
         """
         if hasattr(self, "_key_selection_widget"):
-            self._key_selection_widget.reset_choices()
+            self._key_selection_function_gui.reset_choices()
 
         # reset the axis keys
         self._x_axis_key = None

--- a/src/napari_matplotlib/slice.py
+++ b/src/napari_matplotlib/slice.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import napari
 import numpy as np
 import numpy.typing as npt
-from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel, QSpinBox
+from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel, QSpinBox, QWidget
 
 from .base import NapariMPLWidget
 from .util import Interval
@@ -22,9 +22,13 @@ class SliceWidget(NapariMPLWidget):
     n_layers_input = Interval(1, 1)
     input_layer_types = (napari.layers.Image,)
 
-    def __init__(self, napari_viewer: napari.viewer.Viewer):
+    def __init__(
+        self,
+        napari_viewer: napari.viewer.Viewer,
+        parent: Optional[QWidget] = None,
+    ):
         # Setup figure/axes
-        super().__init__(napari_viewer)
+        super().__init__(napari_viewer, parent=parent)
         self.add_single_axes()
 
         button_layout = QHBoxLayout()

--- a/src/napari_matplotlib/tests/conftest.py
+++ b/src/napari_matplotlib/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 from skimage import data
@@ -22,3 +24,17 @@ def astronaut_data():
 @pytest.fixture
 def brain_data():
     return data.brain(), {"rgb": False}
+
+
+@pytest.fixture(autouse=True, scope="session")
+def set_strict_qt():
+    env_var = "NAPARI_STRICT_QT"
+    old_val = os.environ.get(env_var)
+    os.environ[env_var] = "1"
+    # Run tests
+    yield
+    # Reset to original value
+    if old_val is not None:
+        os.environ[env_var] = old_val
+    else:
+        del os.environ[env_var]

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,5 @@ python =
 [testenv]
 extras = testing
 commands =
-    - python -c 'from skimage import data; data.brain()'
-    - python -m pytest --mpl -v --color=yes --cov=napari_matplotlib --cov-report=xml
+    python -c 'from skimage import data; data.brain()'
+    python -m pytest --mpl -v --color=yes --cov=napari_matplotlib --cov-report=xml


### PR DESCRIPTION
This PR enables a check for leaky QT widgets. This is done in `conftest.py` by setting the "NAPARI_STRICT_QT" environment variable during the tests.

To make the the widgets watertight I had to do two things:
- Consistently use the `parent` keyword argument to make sure all widgets have a parent widget. This is important, because parent widgets will pro-actively close any of their children when they themselves are closed.
- Re-write the features scatter widget to not use `magicgui`. Previously there was a circular reference that prevented the widget and one of the menus `magicgui` created from being cleaned up. I think the new code is a bit more readable if anything, and makes it clear where callbacks are between the combo boxes and the graph drawing. To test this run `examples/features_scatter.py` and have a play around with the widget.

Fixes https://github.com/matplotlib/napari-matplotlib/issues/109