### PR TITLE
Remove indices and tables from doc landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,12 +16,3 @@ map one or more Image layers on to a 1D histogram plot.
 
    auto_examples/index
    api
-
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
These are added by default to new Sphinx docs, but I think this looks odd on the home page, and the features are either not that helpful (index, module index) or duplicated (search, there is a search button on the top right of the page.

![Screenshot 2023-05-15 at 11 36 54](https://github.com/matplotlib/napari-matplotlib/assets/6197628/42f5ab4b-da44-4f81-8b97-1a692989692a)
