### PR TITLE
Remove circular ref in base widget

### DIFF
--- a/src/napari_matplotlib/base.py
+++ b/src/napari_matplotlib/base.py
@@ -48,7 +48,6 @@ class NapariMPLWidget(QWidget):
 
         self.viewer = napari_viewer
         self.canvas = FigureCanvas()
-        self.canvas.widget = self
 
         self.canvas.figure.patch.set_facecolor("none")
         self.canvas.figure.set_layout_engine("constrained")

--- a/src/napari_matplotlib/tests/test_histogram.py
+++ b/src/napari_matplotlib/tests/test_histogram.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 
 from napari_matplotlib import HistogramWidget
@@ -9,4 +11,6 @@ def test_example_q_widget(make_napari_viewer, astronaut_data):
     viewer = make_napari_viewer()
     viewer.add_image(astronaut_data[0], **astronaut_data[1])
     fig = HistogramWidget(viewer).figure
-    return fig
+    # Need to return a copy, as original figure is too eagerley garbage
+    # collected by the widget
+    return deepcopy(fig)

--- a/src/napari_matplotlib/tests/test_slice.py
+++ b/src/napari_matplotlib/tests/test_slice.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 
 from napari_matplotlib import SliceWidget
@@ -8,4 +10,6 @@ def test_slice(make_napari_viewer, brain_data):
     viewer = make_napari_viewer()
     viewer.add_image(brain_data[0], **brain_data[1])
     fig = SliceWidget(viewer).figure
-    return fig
+    # Need to return a copy, as original figure is too eagerley garbage
+    # collected by the widget
+    return deepcopy(fig)


### PR DESCRIPTION
This removes the circular reference we had to introduce to keep the figure canavas around long enough for `pytest-mpl` to do the image comparison. Part of fixing https://github.com/matplotlib/napari-matplotlib/issues/109, but independent enough to be in its own PR.