### PR TITLE
Clean up layer selection API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,9 @@ Changes
   you would be interested in please open an issue at https://github.com/matplotlib/napari-matplotlib.
 - Labels plotting with the features scatter widget no longer have underscores
   replaced with spaces.
+- ``NapariMPLWidget.update_layers()`` has been removed as it is intended to be
+  private API. Use `NapariMPLWidget.on_update_layers` instead to implement
+  funcitonality when layer selection is changed.
 
 Bug fixes
 ~~~~~~~~~

--- a/src/napari_matplotlib/base.py
+++ b/src/napari_matplotlib/base.py
@@ -108,6 +108,12 @@ class NapariMPLWidget(MPLWidget):
     is changed in the napari viewer. To take advantage of this sub-classes
     should implement the ``clear()`` and ``draw()`` methods.
 
+        When both the z-step and layer selection is changed, ``clear()`` is called
+    and if the number a type of selected layers are valid for the widget
+    ``draw()`` is then called. When layer selection is changed ``on_update_layers()``
+    is also called, which can be useful e.g. for updating a layer list in a
+    selection widget.
+
     Attributes
     ----------
     viewer : `napari.Viewer`
@@ -157,14 +163,16 @@ class NapariMPLWidget(MPLWidget):
         # z-step changed in viewer
         self.viewer.dims.events.current_step.connect(self._draw)
         # Layer selection changed in viewer
-        self.viewer.layers.selection.events.changed.connect(self.update_layers)
+        self.viewer.layers.selection.events.changed.connect(
+            self._update_layers
+        )
 
-    def update_layers(self, event: napari.utils.events.Event) -> None:
+    def _update_layers(self, event: napari.utils.events.Event) -> None:
         """
         Update the ``layers`` attribute with currently selected layers and re-draw.
         """
         self.layers = list(self.viewer.layers.selection)
-        self._on_update_layers()
+        self.on_update_layers()
         self._draw()
 
     def _draw(self) -> None:
@@ -193,10 +201,9 @@ class NapariMPLWidget(MPLWidget):
         This is a no-op, and is intended for derived classes to override.
         """
 
-    def _on_update_layers(self) -> None:
+    def on_update_layers(self) -> None:
         """
-        Function is called when self.layers is updated via
-        ``self.update_layers()``.
+        Called when the selected layers are updated.
 
         This is a no-op, and is intended for derived classes to override.
         """

--- a/src/napari_matplotlib/histogram.py
+++ b/src/napari_matplotlib/histogram.py
@@ -27,7 +27,7 @@ class HistogramWidget(NapariMPLWidget):
     ):
         super().__init__(napari_viewer, parent=parent)
         self.add_single_axes()
-        self.update_layers(None)
+        self._update_layers(None)
 
     def clear(self) -> None:
         """

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -132,7 +132,7 @@ class FeaturesScatterWidget(ScatterBaseWidget):
             self.layout().addWidget(QLabel(f"{dim}-axis:"))
             self.layout().addWidget(self._selectors[dim])
 
-        self.update_layers(None)
+        self._update_layers(None)
 
     @property
     def x_axis_key(self) -> Union[str, None]:
@@ -230,7 +230,7 @@ class FeaturesScatterWidget(ScatterBaseWidget):
 
         return x, y, x_axis_name, y_axis_name
 
-    def _on_update_layers(self) -> None:
+    def on_update_layers(self) -> None:
         """
         Called when the layer selection changes by ``self.update_layers()``.
         """

--- a/src/napari_matplotlib/slice.py
+++ b/src/napari_matplotlib/slice.py
@@ -51,7 +51,7 @@ class SliceWidget(NapariMPLWidget):
         for d in _dims_sel:
             self.slice_selectors[d].textChanged.connect(self._draw)
 
-        self.update_layers(None)
+        self._update_layers(None)
 
     @property
     def _layer(self) -> napari.layers.Layer:


### PR DESCRIPTION
Again, while working on https://github.com/matplotlib/napari-matplotlib/pull/127 I realised the API for doing stuff when the layer selection is changed wasn't clear. I've added more to the `NapariMPLWidget` docstring explaining this, and switched:
- `on_layer_selection()` from private to public, since derived classes are meant to override this
- `update_layers()` from public to private, since derived classes are **not** meant to override this