### PR TITLE
Tests for background lightness checking.

### DIFF
--- a/src/napari_matplotlib/tests/test_theme.py
+++ b/src/napari_matplotlib/tests/test_theme.py
@@ -34,7 +34,9 @@ def _mock_up_theme() -> None:
 
 
 def test_theme_background_check(make_napari_viewer):
-    """Check that the hue, saturation, lightness can distinguish dark and light backgrounds."""
+    """
+    Check that the hue saturation lightness can distinguish dark and light backgrounds.
+    """
     viewer = make_napari_viewer()
     widget = NapariMPLWidget(viewer)
 

--- a/src/napari_matplotlib/tests/test_theme.py
+++ b/src/napari_matplotlib/tests/test_theme.py
@@ -1,3 +1,4 @@
+import napari
 import pytest
 
 from napari_matplotlib.base import NapariMPLWidget
@@ -18,3 +19,31 @@ def test_theme_mpl_toolbar_icons(
     assert (
         path_to_icons.stem == expected_icons
     ), "The theme is selecting unexpected icons."
+
+
+def _mock_up_theme() -> None:
+    """Mock up a new color theme based on dark mode but with a tasteful blue background.
+
+    Based on:
+    https://napari.org/stable/gallery/new_theme.html
+    """
+    blue_theme = napari.utils.theme.get_theme("dark", False)
+    blue_theme.name = "blue"
+    blue_theme.background = "#4169e1"  # my favourite shade of blue
+    napari.utils.theme.register_theme("blue", blue_theme)
+
+
+def test_theme_background_check(make_napari_viewer):
+    """Check that the hue, saturation, lightness can distinguish dark and light backgrounds."""
+    viewer = make_napari_viewer()
+    widget = NapariMPLWidget(viewer)
+
+    viewer.theme = "dark"
+    assert widget._theme_has_light_bg() is False
+
+    viewer.theme = "light"
+    assert widget._theme_has_light_bg() is True
+
+    _mock_up_theme()
+    viewer.theme = "blue"
+    assert widget._theme_has_light_bg() is True


### PR DESCRIPTION
So I intended to factor out [``NapariMPLWidget._theme_has_light_bg‎``](https://github.com/matplotlib/napari-matplotlib/blob/main/src/napari_matplotlib/base.py#L109) as a peripheral from #138.

But the change crept in 😱 and did so without tests 😱😱. Note that it was in the [address PR comments commit](https://github.com/matplotlib/napari-matplotlib/commit/010a02e350cad1a360cccfccdbb932590f1571d3) so might have snuck in unapproved. Sorry about that. Careless.

In any case here's a test.

I can also pull out `_theme_has_light_bg` if you think it'd be better upstream. For example as a member `@property` on [``napari.utils.theme.Theme``](https://github.com/napari/napari/blob/main/napari/utils/theme.py#L34).