### PR TITLE
`ICON_ROOT` no longer needs to be a global.

### DIFF
--- a/src/napari_matplotlib/base.py
+++ b/src/napari_matplotlib/base.py
@@ -14,9 +14,6 @@ from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from .util import Interval, from_napari_css_get_size_of
 
-# Icons modified from
-# https://github.com/matplotlib/matplotlib/tree/main/lib/matplotlib/mpl-data/images
-ICON_ROOT = Path(__file__).parent / "icons"
 __all__ = ["BaseNapariMPLWidget", "NapariMPLWidget"]
 
 
@@ -122,11 +119,15 @@ class BaseNapariMPLWidget(QWidget):
     def _get_path_to_icon(self) -> Path:
         """
         Get the icons directory (which is theme-dependent).
+
+        Icons modified from
+        https://github.com/matplotlib/matplotlib/tree/main/lib/matplotlib/mpl-data/images
         """
+        icon_root = Path(__file__).parent / "icons"
         if self._theme_has_light_bg():
-            return ICON_ROOT / "black"
+            return icon_root / "black"
         else:
-            return ICON_ROOT / "white"
+            return icon_root / "white"
 
     def _replace_toolbar_icons(self) -> None:
         """


### PR DESCRIPTION
Now `ICON_ROOT` is only needed by one function in one class, it doesn't need to be global. (Unless we want it like that?)

Feel free to decline if undesired.