### PR TITLE
Add a mocker test for `__version__` fallback.

### DIFF
--- a/src/napari_matplotlib/tests/test_util.py
+++ b/src/napari_matplotlib/tests/test_util.py
@@ -1,7 +1,20 @@
+import importlib
+import sys
+
 import pytest
 from qtpy.QtCore import QSize
 
 from napari_matplotlib.util import Interval, from_napari_css_get_size_of
+
+
+def test_version_fallback(mocker):
+    """Test the versioning fallback (in case setuptools_scm didn't work)"""
+    import napari_matplotlib  # fmt: skip
+    assert napari_matplotlib.__version__ != "unknown"  # type: ignore[attr-defined]
+
+    mocker.patch.dict(sys.modules, {"napari_matplotlib._version": None})
+    importlib.reload(napari_matplotlib)
+    assert napari_matplotlib.__version__ == "unknown"  # type: ignore[attr-defined]
 
 
 def test_interval():


### PR DESCRIPTION
Test the versioning fallback code by using the mocker to patch ``sys.modules``.

A little bit trivial, but moves us closer to 100% coverage. This might make it easier to spot coverage drops. And also good for developer morale.