### PR TITLE
Check that single layer widget plots change w/ layer change

### DIFF
--- a/src/napari_matplotlib/tests/test_histogram.py
+++ b/src/napari_matplotlib/tests/test_histogram.py
@@ -3,10 +3,6 @@ from copy import deepcopy
 import pytest
 
 from napari_matplotlib import HistogramWidget
-from napari_matplotlib.tests.helpers import (
-    assert_figures_equal,
-    assert_figures_not_equal,
-)
 
 
 @pytest.mark.mpl_image_compare
@@ -27,26 +23,3 @@ def test_histogram_3D(make_napari_viewer, brain_data):
     # Need to return a copy, as original figure is too eagerley garbage
     # collected by the widget
     return deepcopy(fig)
-
-
-def test_change_layer(make_napari_viewer, brain_data, astronaut_data):
-    viewer = make_napari_viewer()
-    widget = HistogramWidget(viewer)
-
-    viewer.add_image(brain_data[0], **brain_data[1])
-    viewer.add_image(astronaut_data[0], **astronaut_data[1])
-
-    # Select first layer
-    viewer.layers.selection.clear()
-    viewer.layers.selection.add(viewer.layers[0])
-    fig1 = deepcopy(widget.figure)
-
-    # Re-selecting first layer should produce identical plot
-    viewer.layers.selection.clear()
-    viewer.layers.selection.add(viewer.layers[0])
-    assert_figures_equal(widget.figure, fig1)
-
-    # Plotting the second layer should produce a different plot
-    viewer.layers.selection.clear()
-    viewer.layers.selection.add(viewer.layers[1])
-    assert_figures_not_equal(widget.figure, fig1)

--- a/src/napari_matplotlib/tests/test_layer_changes.py
+++ b/src/napari_matplotlib/tests/test_layer_changes.py
@@ -1,0 +1,59 @@
+from copy import deepcopy
+from typing import Any, Dict, Tuple, Type
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+from napari.viewer import Viewer
+
+from napari_matplotlib import HistogramWidget, SliceWidget
+from napari_matplotlib.base import NapariMPLWidget
+from napari_matplotlib.tests.helpers import (
+    assert_figures_equal,
+    assert_figures_not_equal,
+)
+
+
+@pytest.mark.parametrize("widget_cls", [HistogramWidget, SliceWidget])
+def test_change_one_layer(
+    make_napari_viewer, brain_data, astronaut_data, widget_cls
+):
+    """
+    Test all widgets that take one layer as input to make sure the plot changes
+    when the napari layer selection changes.
+    """
+    viewer = make_napari_viewer()
+    assert_one_layer_plot_changes(
+        viewer, widget_cls, brain_data, astronaut_data
+    )
+
+
+def assert_one_layer_plot_changes(
+    viewer: Viewer,
+    widget_cls: Type[NapariMPLWidget],
+    data1: Tuple[npt.NDArray[np.generic], Dict[str, Any]],
+    data2: Tuple[npt.NDArray[np.generic], Dict[str, Any]],
+) -> None:
+    """
+    When the selected layer is changed, make sure the plot generated
+    by `widget_cls` also changes.
+    """
+    widget = widget_cls(viewer)
+
+    viewer.add_image(data1[0], **data1[1])
+    viewer.add_image(data2[0], **data2[1])
+
+    # Select first layer
+    viewer.layers.selection.clear()
+    viewer.layers.selection.add(viewer.layers[0])
+    fig1 = deepcopy(widget.figure)
+
+    # Re-selecting first layer should produce identical plot
+    viewer.layers.selection.clear()
+    viewer.layers.selection.add(viewer.layers[0])
+    assert_figures_equal(widget.figure, fig1)
+
+    # Plotting the second layer should produce a different plot
+    viewer.layers.selection.clear()
+    viewer.layers.selection.add(viewer.layers[1])
+    assert_figures_not_equal(widget.figure, fig1)


### PR DESCRIPTION
This generalises the test I added in https://github.com/matplotlib/napari-matplotlib/pull/146 to make it easy to test any widget that takes a single layer as input. Although we only have two widgets at the moment, any new widgets just need to be added to `@pytest.mark.parametrize("widget_cls", [HistogramWidget, SliceWidget])` in the future and they'll be automatically tested.

More work towards https://github.com/matplotlib/napari-matplotlib/issues/7.