### PR TITLE
A simple test of `NapariNavigationToolbar._update_buttons_checked`.

### DIFF
--- a/src/napari_matplotlib/tests/test_ui.py
+++ b/src/napari_matplotlib/tests/test_ui.py
@@ -1,0 +1,49 @@
+import pytest
+from qtpy.QtCore import QSize
+from qtpy.QtGui import QImage
+
+from napari_matplotlib import HistogramWidget, ScatterWidget, SliceWidget
+
+
+def _are_different(a: QImage, b: QImage) -> bool:
+    """
+    Check that a and b are identical, pixel by pixel. Via a stupid nested for loop.
+    """
+    assert not a.isNull()
+    assert not b.isNull()
+    assert a.size() == b.size()
+    for x in range(a.width()):
+        for y in range(a.height()):
+            if a.pixel(x, y) != b.pixel(x, y):
+                return True  # exit quickly
+    return False
+
+
+@pytest.mark.parametrize(
+    "Widget", [HistogramWidget, ScatterWidget, SliceWidget]
+)
+def test_mpl_toolbar_buttons_checked(make_napari_viewer, Widget):
+    """Test that the icons for checkable actions change when when a tool is selected.
+
+    A simple test of NapariNavigationToolbar._update_buttons_checked. Make sure the
+    checked and unchecked icons are not the same.
+    """
+    checkable_actions = ["Zoom", "Pan"]
+
+    viewer = make_napari_viewer()
+    widget = Widget(viewer)
+
+    # search through all of the icons for the ones whose icons are expected to
+    # change when checked
+    for action in widget.toolbar.actions():
+        if action.text() in checkable_actions:
+            assert action.isChecked() is False
+            assert action.isCheckable() is True
+            unchecked = action.icon().pixmap(QSize(48, 48)).toImage()
+
+            # simulate the user click (QTest.mouseClick can't take a QAction)
+            action.trigger()
+
+            assert action.isChecked() is True
+            checked = action.icon().pixmap(QSize(48, 48)).toImage()
+            assert _are_different(unchecked, checked)


### PR DESCRIPTION
Inspired by the codecov report, the `_update_buttons_checked` method of the `NapariNavigationToolbar` is [untested](https://app.codecov.io/gh/matplotlib/napari-matplotlib/blob/main/src%2Fnapari_matplotlib%2Fbase.py#L283). So here's a (slightly) dumb UI test.

If anyone knows a better way to compare two `QImage`s I'm really open to it. 

Buuuut it [does seem like a nested `for` loop is the simplest way to do this](https://stackoverflow.com/questions/9134597/how-to-get-rgb-values-of-qpixmap-or-qimage-pixel-qt-pyqt). (For reference: [there seems to be an unlooping way to shove the data into a `numpy array`](https://stackoverflow.com/a/53406117/1444054), but it involves pointers, and I'm not sure it's more readable. Readability counts?) I *did* check the time and the loopy way in this PR is ones of milliseconds.

### Testing:

Things I've done:
* Used ``QImage.save`` to dump the images.
* Replace the quick `return True` with
  ```python
  print(f"a[{x}, {y}] = {a.pixel(x, y)}, \t b[{x}, {y}] = {b.pixel(x, y)}")
  ```
  to verify that a copy of the same image is pixel-by-pixel the same, and that the checked and unchecked are pixel-by-pixel different.

### Notes for reviewers:

As mentioned: I am not a fan of the nested for loops.

Low priority and independent test. So don't rush to review this. It's unlikely to conflict 👍 .


