### PR TITLE
Don't duplicate CI on merge to main

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -2,8 +2,6 @@ name: tests
 
 on:
   push:
-    branches:
-      - main
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:


### PR DESCRIPTION
Currently it looks like CI is run on both push to main, and merge_group via the merge queue. This PR removes that duplication by not running CI on push to main.

Possibly related to https://github.com/matplotlib/napari-matplotlib/issues/155??