### PR TITLE
Generalise functionality for plotting from feature tables

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,3 +8,5 @@ plots though the napari user interface.
 .. automodapi:: napari_matplotlib
 
 .. automodapi:: napari_matplotlib.base
+
+.. automodapi:: napari_matplotlib.features

--- a/src/napari_matplotlib/base.py
+++ b/src/napari_matplotlib/base.py
@@ -281,7 +281,9 @@ class SingleAxesWidget(NapariMPLWidget):
         napari_viewer: napari.viewer.Viewer,
         parent: Optional[QWidget] = None,
     ):
-        super().__init__(napari_viewer=napari_viewer, parent=parent)
+        NapariMPLWidget.__init__(
+            self, napari_viewer=napari_viewer, parent=parent
+        )
         self.add_single_axes()
 
     def clear(self) -> None:

--- a/src/napari_matplotlib/features.py
+++ b/src/napari_matplotlib/features.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import napari.layers
 
 from napari_matplotlib.base import NapariMPLWidget
@@ -19,3 +21,18 @@ class FeaturesMixin(NapariMPLWidget):
         napari.layers.Tracks,
         napari.layers.Vectors,
     )
+
+    def _get_valid_axis_keys(self) -> List[str]:
+        """
+        Get the valid axis keys from the layer FeatureTable.
+
+        Returns
+        -------
+        axis_keys : List[str]
+            The valid axis keys in the FeatureTable. If the table is empty
+            or there isn't a table, returns an empty list.
+        """
+        if len(self.layers) == 0 or not (hasattr(self.layers[0], "features")):
+            return []
+        else:
+            return self.layers[0].features.keys()

--- a/src/napari_matplotlib/features.py
+++ b/src/napari_matplotlib/features.py
@@ -1,7 +1,10 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import napari
 import napari.layers
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
 from qtpy.QtWidgets import QComboBox, QLabel, QVBoxLayout
 
 from napari_matplotlib.base import NapariMPLWidget
@@ -85,6 +88,27 @@ class FeaturesMixin(NapariMPLWidget):
             and len(feature_table) > 0
             and all([self.get_key(dim) in valid_keys for dim in self.dims])
         )
+
+    def _get_data_names(
+        self,
+    ) -> Tuple[List[npt.NDArray[Any]], List[str]]:
+        """
+        Get the plot data from the ``features`` attribute of the first
+        selected layer.
+
+        Returns
+        -------
+        data : List[np.ndarray]
+            List contains X and Y columns from the FeatureTable. Returns
+            an empty array if nothing to plot.
+        names : List[str]
+            Names for each axis.
+        """
+        feature_table: pd.DataFrame = self.layers[0].features
+
+        names = [str(self.get_key(dim)) for dim in self.dims]
+        data = [np.array(feature_table[key]) for key in names]
+        return data, names
 
     def on_update_layers(self) -> None:
         """

--- a/src/napari_matplotlib/features.py
+++ b/src/napari_matplotlib/features.py
@@ -70,6 +70,22 @@ class FeaturesMixin(NapariMPLWidget):
         else:
             return self.layers[0].features.keys()
 
+    def _ready_to_plot(self) -> bool:
+        """
+        Return True if selected layer has a feature table we can plot with,
+        and the columns to plot have been selected.
+        """
+        if not hasattr(self.layers[0], "features"):
+            return False
+
+        feature_table = self.layers[0].features
+        valid_keys = self._get_valid_axis_keys()
+        return (
+            feature_table is not None
+            and len(feature_table) > 0
+            and all([self.get_key(dim) in valid_keys for dim in self.dims])
+        )
+
     def on_update_layers(self) -> None:
         """
         Called when the layer selection changes by ``self.update_layers()``.

--- a/src/napari_matplotlib/features.py
+++ b/src/napari_matplotlib/features.py
@@ -69,3 +69,14 @@ class FeaturesMixin(NapariMPLWidget):
             return []
         else:
             return self.layers[0].features.keys()
+
+    def on_update_layers(self) -> None:
+        """
+        Called when the layer selection changes by ``self.update_layers()``.
+        """
+        # Clear combobox
+        for dim in self.dims:
+            while self._selectors[dim].count() > 0:
+                self._selectors[dim].removeItem(0)
+            # Add keys for newly selected layer
+            self._selectors[dim].addItems(self._get_valid_axis_keys())

--- a/src/napari_matplotlib/features.py
+++ b/src/napari_matplotlib/features.py
@@ -19,6 +19,7 @@ class FeaturesMixin(NapariMPLWidget):
     in a single napari layer.
 
     This provides:
+
     - Setup for one or two combo boxes to select features to be plotted.
     - An ``on_update_layers()`` callback that updates the combo box options
       when the napari layer selection changes.

--- a/src/napari_matplotlib/features.py
+++ b/src/napari_matplotlib/features.py
@@ -1,6 +1,8 @@
-from typing import List
+from typing import Dict, List
 
+import napari
 import napari.layers
+from qtpy.QtWidgets import QComboBox, QLabel, QVBoxLayout
 
 from napari_matplotlib.base import NapariMPLWidget
 from napari_matplotlib.util import Interval
@@ -10,6 +12,12 @@ class FeaturesMixin(NapariMPLWidget):
     """
     Mixin to help with widgets that plot data from a features table stored
     on a single layer.
+
+    Notes
+    -----
+    This currently only works for widgets that plot two quatities against each other
+    e.g., scatter plots. It is intended to be generalised in the future for widgets
+    that plot one quantity e.g., histograms.
     """
 
     n_layers_input = Interval(1, 1)
@@ -21,6 +29,19 @@ class FeaturesMixin(NapariMPLWidget):
         napari.layers.Tracks,
         napari.layers.Vectors,
     )
+
+    def __init__(self) -> None:
+        # Set up selection boxes
+        self.layout().addLayout(QVBoxLayout())
+
+        self._selectors: Dict[str, QComboBox] = {}
+        for dim in ["x", "y"]:
+            self._selectors[dim] = QComboBox()
+            # Re-draw when combo boxes are updated
+            self._selectors[dim].currentTextChanged.connect(self._draw)
+
+            self.layout().addWidget(QLabel(f"{dim}-axis:"))
+            self.layout().addWidget(self._selectors[dim])
 
     def _get_valid_axis_keys(self) -> List[str]:
         """

--- a/src/napari_matplotlib/features.py
+++ b/src/napari_matplotlib/features.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import napari
 import napari.layers
@@ -12,12 +12,6 @@ class FeaturesMixin(NapariMPLWidget):
     """
     Mixin to help with widgets that plot data from a features table stored
     on a single layer.
-
-    Notes
-    -----
-    This currently only works for widgets that plot two quatities against each other
-    e.g., scatter plots. It is intended to be generalised in the future for widgets
-    that plot one quantity e.g., histograms.
     """
 
     n_layers_input = Interval(1, 1)
@@ -30,18 +24,36 @@ class FeaturesMixin(NapariMPLWidget):
         napari.layers.Vectors,
     )
 
-    def __init__(self) -> None:
+    def __init__(self, *, ndim: int) -> None:
+        assert ndim in [1, 2]
+        self.dims = ["x", "y"][:ndim]
         # Set up selection boxes
         self.layout().addLayout(QVBoxLayout())
 
         self._selectors: Dict[str, QComboBox] = {}
-        for dim in ["x", "y"]:
+        for dim in self.dims:
             self._selectors[dim] = QComboBox()
             # Re-draw when combo boxes are updated
             self._selectors[dim].currentTextChanged.connect(self._draw)
 
             self.layout().addWidget(QLabel(f"{dim}-axis:"))
             self.layout().addWidget(self._selectors[dim])
+
+    def get_key(self, dim: str) -> Optional[str]:
+        """
+        Get key for a given dimension.
+        """
+        if self._selectors[dim].count() == 0:
+            return None
+        else:
+            return self._selectors[dim].currentText()
+
+    def set_key(self, dim: str, value: str) -> None:
+        """
+        Set key for a given dimension.
+        """
+        self._selectors[dim].setCurrentText(value)
+        self._draw()
 
     def _get_valid_axis_keys(self) -> List[str]:
         """

--- a/src/napari_matplotlib/features.py
+++ b/src/napari_matplotlib/features.py
@@ -1,0 +1,21 @@
+import napari.layers
+
+from napari_matplotlib.base import NapariMPLWidget
+from napari_matplotlib.util import Interval
+
+
+class FeaturesMixin(NapariMPLWidget):
+    """
+    Mixin to help with widgets that plot data from a features table stored
+    on a single layer.
+    """
+
+    n_layers_input = Interval(1, 1)
+    # All layers that have a .features attributes
+    input_layer_types = (
+        napari.layers.Labels,
+        napari.layers.Points,
+        napari.layers.Shapes,
+        napari.layers.Tracks,
+        napari.layers.Vectors,
+    )

--- a/src/napari_matplotlib/features.py
+++ b/src/napari_matplotlib/features.py
@@ -12,10 +12,16 @@ from napari_matplotlib.util import Interval
 
 __all__ = ["FeaturesMixin"]
 
+
 class FeaturesMixin(NapariMPLWidget):
     """
     Mixin to help with widgets that plot data from a features table stored
-    on a single layer.
+    in a single napari layer.
+
+    This provides:
+    - Setup for one or two combo boxes to select features to be plotted.
+    - An ``on_update_layers()`` callback that updates the combo box options
+      when the napari layer selection changes.
     """
 
     n_layers_input = Interval(1, 1)
@@ -29,6 +35,13 @@ class FeaturesMixin(NapariMPLWidget):
     )
 
     def __init__(self, *, ndim: int) -> None:
+        """
+        Parameters
+        ----------
+        ndim : int
+            Number of dimensions that are plotted by the widget.
+            Must be 1 or 2.
+        """
         assert ndim in [1, 2]
         self.dims = ["x", "y"][:ndim]
         # Set up selection boxes
@@ -46,6 +59,11 @@ class FeaturesMixin(NapariMPLWidget):
     def get_key(self, dim: str) -> Optional[str]:
         """
         Get key for a given dimension.
+
+        Parameters
+        ----------
+        dim : str
+            "x" or "y"
         """
         if self._selectors[dim].count() == 0:
             return None
@@ -55,13 +73,24 @@ class FeaturesMixin(NapariMPLWidget):
     def set_key(self, dim: str, value: str) -> None:
         """
         Set key for a given dimension.
+
+        Parameters
+        ----------
+        dim : str
+            "x" or "y"
+        value : str
+            Value to set.
         """
+        assert value in self._get_valid_axis_keys(), (
+            "value must be on of the columns "
+            "of the feature table on the currently seleted layer"
+        )
         self._selectors[dim].setCurrentText(value)
         self._draw()
 
     def _get_valid_axis_keys(self) -> List[str]:
         """
-        Get the valid axis keys from the layer FeatureTable.
+        Get the valid axis keys from the features table column names.
 
         Returns
         -------

--- a/src/napari_matplotlib/features.py
+++ b/src/napari_matplotlib/features.py
@@ -10,6 +10,7 @@ from qtpy.QtWidgets import QComboBox, QLabel, QVBoxLayout
 from napari_matplotlib.base import NapariMPLWidget
 from napari_matplotlib.util import Interval
 
+__all__ = ["FeaturesMixin"]
 
 class FeaturesMixin(NapariMPLWidget):
     """

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import napari
 import numpy.typing as npt
-from qtpy.QtWidgets import QComboBox, QLabel, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QWidget
 
 from .base import SingleAxesWidget
 from .features import FeaturesMixin
@@ -96,19 +96,8 @@ class FeaturesScatterWidget(ScatterBaseWidget, FeaturesMixin):
         napari_viewer: napari.viewer.Viewer,
         parent: Optional[QWidget] = None,
     ):
-        super().__init__(napari_viewer, parent=parent)
-
-        self.layout().addLayout(QVBoxLayout())
-
-        self._selectors: Dict[str, QComboBox] = {}
-        for dim in ["x", "y"]:
-            self._selectors[dim] = QComboBox()
-            # Re-draw when combo boxes are updated
-            self._selectors[dim].currentTextChanged.connect(self._draw)
-
-            self.layout().addWidget(QLabel(f"{dim}-axis:"))
-            self.layout().addWidget(self._selectors[dim])
-
+        ScatterBaseWidget.__init__(self, napari_viewer, parent=parent)
+        FeaturesMixin.__init__(self)
         self._update_layers(None)
 
     @property

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -100,28 +100,11 @@ class FeaturesScatterWidget(ScatterBaseWidget, FeaturesMixin):
         FeaturesMixin.__init__(self, ndim=2)
         self._update_layers(None)
 
-    def _ready_to_scatter(self) -> bool:
-        """
-        Return True if selected layer has a feature table we can scatter with,
-        and the two columns to be scatterd have been selected.
-        """
-        if not hasattr(self.layers[0], "features"):
-            return False
-
-        feature_table = self.layers[0].features
-        valid_keys = self._get_valid_axis_keys()
-        return (
-            feature_table is not None
-            and len(feature_table) > 0
-            and self.get_key("x") in valid_keys
-            and self.get_key("y") in valid_keys
-        )
-
     def draw(self) -> None:
         """
         Scatter two features from the currently selected layer.
         """
-        if self._ready_to_scatter():
+        if self._ready_to_plot():
             super().draw()
 
     def _get_data(self) -> Tuple[npt.NDArray[Any], npt.NDArray[Any], str, str]:

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import napari
 import numpy.typing as npt
@@ -140,21 +140,6 @@ class FeaturesScatterWidget(ScatterBaseWidget, FeaturesMixin):
     def y_axis_key(self, key: str) -> None:
         self._selectors["y"].setCurrentText(key)
         self._draw()
-
-    def _get_valid_axis_keys(self) -> List[str]:
-        """
-        Get the valid axis keys from the layer FeatureTable.
-
-        Returns
-        -------
-        axis_keys : List[str]
-            The valid axis keys in the FeatureTable. If the table is empty
-            or there isn't a table, returns an empty list.
-        """
-        if len(self.layers) == 0 or not (hasattr(self.layers[0], "features")):
-            return []
-        else:
-            return self.layers[0].features.keys()
 
     def _ready_to_scatter(self) -> bool:
         """

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -150,14 +150,3 @@ class FeaturesScatterWidget(ScatterBaseWidget, FeaturesMixin):
         y_axis_name = str(self.get_key("y"))
 
         return x, y, x_axis_name, y_axis_name
-
-    def on_update_layers(self) -> None:
-        """
-        Called when the layer selection changes by ``self.update_layers()``.
-        """
-        # Clear combobox
-        for dim in ["x", "y"]:
-            while self._selectors[dim].count() > 0:
-                self._selectors[dim].removeItem(0)
-            # Add keys for newly selected layer
-            self._selectors[dim].addItems(self._get_valid_axis_keys())

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -5,6 +5,7 @@ import numpy.typing as npt
 from qtpy.QtWidgets import QComboBox, QLabel, QVBoxLayout, QWidget
 
 from .base import SingleAxesWidget
+from .features import FeaturesMixin
 from .util import Interval
 
 __all__ = ["ScatterBaseWidget", "ScatterWidget", "FeaturesScatterWidget"]
@@ -85,20 +86,10 @@ class ScatterWidget(ScatterBaseWidget):
         return x, y, x_axis_name, y_axis_name
 
 
-class FeaturesScatterWidget(ScatterBaseWidget):
+class FeaturesScatterWidget(ScatterBaseWidget, FeaturesMixin):
     """
     Widget to scatter data stored in two layer feature attributes.
     """
-
-    n_layers_input = Interval(1, 1)
-    # All layers that have a .features attributes
-    input_layer_types = (
-        napari.layers.Labels,
-        napari.layers.Points,
-        napari.layers.Shapes,
-        napari.layers.Tracks,
-        napari.layers.Vectors,
-    )
 
     def __init__(
         self,

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional, Tuple
 
 import napari
 import numpy.typing as npt
@@ -97,38 +97,8 @@ class FeaturesScatterWidget(ScatterBaseWidget, FeaturesMixin):
         parent: Optional[QWidget] = None,
     ):
         ScatterBaseWidget.__init__(self, napari_viewer, parent=parent)
-        FeaturesMixin.__init__(self)
+        FeaturesMixin.__init__(self, ndim=2)
         self._update_layers(None)
-
-    @property
-    def x_axis_key(self) -> Union[str, None]:
-        """
-        Key for the x-axis data.
-        """
-        if self._selectors["x"].count() == 0:
-            return None
-        else:
-            return self._selectors["x"].currentText()
-
-    @x_axis_key.setter
-    def x_axis_key(self, key: str) -> None:
-        self._selectors["x"].setCurrentText(key)
-        self._draw()
-
-    @property
-    def y_axis_key(self) -> Union[str, None]:
-        """
-        Key for the y-axis data.
-        """
-        if self._selectors["y"].count() == 0:
-            return None
-        else:
-            return self._selectors["y"].currentText()
-
-    @y_axis_key.setter
-    def y_axis_key(self, key: str) -> None:
-        self._selectors["y"].setCurrentText(key)
-        self._draw()
 
     def _ready_to_scatter(self) -> bool:
         """
@@ -143,8 +113,8 @@ class FeaturesScatterWidget(ScatterBaseWidget, FeaturesMixin):
         return (
             feature_table is not None
             and len(feature_table) > 0
-            and self.x_axis_key in valid_keys
-            and self.y_axis_key in valid_keys
+            and self.get_key("x") in valid_keys
+            and self.get_key("y") in valid_keys
         )
 
     def draw(self) -> None:
@@ -173,11 +143,11 @@ class FeaturesScatterWidget(ScatterBaseWidget, FeaturesMixin):
         """
         feature_table = self.layers[0].features
 
-        x = feature_table[self.x_axis_key]
-        y = feature_table[self.y_axis_key]
+        x = feature_table[self.get_key("x")]
+        y = feature_table[self.get_key("y")]
 
-        x_axis_name = str(self.x_axis_key)
-        y_axis_name = str(self.y_axis_key)
+        x_axis_name = str(self.get_key("x"))
+        y_axis_name = str(self.get_key("y"))
 
         return x, y, x_axis_name, y_axis_name
 

--- a/src/napari_matplotlib/scatter.py
+++ b/src/napari_matplotlib/scatter.py
@@ -108,28 +108,5 @@ class FeaturesScatterWidget(ScatterBaseWidget, FeaturesMixin):
             super().draw()
 
     def _get_data(self) -> Tuple[npt.NDArray[Any], npt.NDArray[Any], str, str]:
-        """
-        Get the plot data from the ``features`` attribute of the first
-        selected layer.
-
-        Returns
-        -------
-        data : List[np.ndarray]
-            List contains X and Y columns from the FeatureTable. Returns
-            an empty array if nothing to plot.
-        x_axis_name : str
-            The title to display on the x axis. Returns
-            an empty string if nothing to plot.
-        y_axis_name: str
-            The title to display on the y axis. Returns
-            an empty string if nothing to plot.
-        """
-        feature_table = self.layers[0].features
-
-        x = feature_table[self.get_key("x")]
-        y = feature_table[self.get_key("y")]
-
-        x_axis_name = str(self.get_key("x"))
-        y_axis_name = str(self.get_key("y"))
-
-        return x, y, x_axis_name, y_axis_name
+        data, names = self._get_data_names()
+        return data[0], data[1], names[0], names[1]

--- a/src/napari_matplotlib/tests/scatter/test_scatter_features.py
+++ b/src/napari_matplotlib/tests/scatter/test_scatter_features.py
@@ -25,8 +25,8 @@ def test_features_scatter_widget_2D(
 
     # Select points data and chosen features
     viewer.layers.selection.add(viewer.layers[0])  # images need to be selected
-    widget.x_axis_key = "feature_0"
-    widget.y_axis_key = "feature_1"
+    widget.set_key("x", "feature_0")
+    widget.set_key("y", "feature_1")
 
     fig = widget.figure
 
@@ -64,9 +64,9 @@ def test_features_scatter_get_data(make_napari_viewer):
     viewer.layers.selection = [labels_layer]
 
     x_column = "feature_0"
-    scatter_widget.x_axis_key = x_column
     y_column = "feature_2"
-    scatter_widget.y_axis_key = y_column
+    scatter_widget.set_key("x", x_column)
+    scatter_widget.set_key("y", y_column)
 
     x, y, x_axis_name, y_axis_name = scatter_widget._get_data()
     np.testing.assert_allclose(x, feature_table[x_column])


### PR DESCRIPTION
There is currently one widget that plots data stored in the `.features` attribute of layers (`FeaturesScatterWidget`). There is demand to add more of these though, see https://github.com/matplotlib/napari-matplotlib/pull/61, https://github.com/matplotlib/napari-matplotlib/pull/63, https://github.com/matplotlib/napari-matplotlib/pull/148, https://github.com/matplotlib/napari-matplotlib/issues/60, https://github.com/matplotlib/napari-matplotlib/issues/58

This PR separates the functionality for plotting from a features layer into a new class, which will make it much easier to expand the widgets that plot from features in the future.