### PR TITLE
Don't run coverage upload on merge queue

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -58,6 +58,9 @@ jobs:
 
       - name: Coverage
         uses: codecov/codecov-action@v3
+        # Don't run coverage on merge queue CI to avoid duplicating reports
+        # to codecov. See https://github.com/matplotlib/napari-matplotlib/issues/155
+        if: github.event_name != 'merge_group'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
Should fix https://github.com/matplotlib/napari-matplotlib/issues/155?? I think the only way to test this is to merge it.