### PR TITLE
Add doc deployment job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-docs
     steps:
+    - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
       with:
         name: docs


### PR DESCRIPTION
This is a cherry-pick of the first commit from #166 but where the branch is not from a fork, but from @matplotlib's repo directly.

Probably you need to set up the pages from the [``gh-pages``](https://github.com/matplotlib/napari-matplotlib/tree/gh-pages) branch in the repo settings? Because there's nothing at https://matplotlib.github.io/napari-matplotlib