### PR TITLE
Extra toolbar buttons option

### DIFF
--- a/examples/toolbar_extra_button.py
+++ b/examples/toolbar_extra_button.py
@@ -1,0 +1,20 @@
+import napari
+from pathlib import Path
+from napari_matplotlib.base import NapariMPLWidget
+
+click_icon_file_path = (Path(__file__).parent.parent / "src/napari_matplotlib/icons/black/Forward.png").__str__()
+
+
+def on_click():
+    print("clicked")
+
+
+viewer = napari.Viewer()
+
+plotter = NapariMPLWidget(viewer)
+plotter.toolbar._add_new_button(
+    'click', "Print click", click_icon_file_path, on_click, False)
+
+viewer.window.add_dock_widget(plotter)
+
+napari.run()


### PR DESCRIPTION
Hi napari-matplotlib developers,

I am working with extra buttons in the toolbar. I am currently using this code to be able to add extra buttons to it.
I hoped this could be another contribution to napari-matplotlib! 🚀 
Maybe other developers could benefit as well and, of course in my case, I wouldn't need to subclass anymore just for that.

I am providing a MWE (`toolbar_extra_button.py`), which adds one of the black buttons as an extra button.

Could this backend feature be in the scope of what you envision for this plugin?
Looking forward to your opinions on this!
