### PR TITLE
Pin Matplotlib to < 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: v1.5.1
     hooks:
      - id: mypy
-       additional_dependencies: [numpy, matplotlib]
+       additional_dependencies: [numpy, matplotlib<3.8]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    matplotlib
+    matplotlib<3.8
     napari
     numpy
     tinycss2


### PR DESCRIPTION
Test failures seem to be due to a new Matplotlib release