### PR TITLE
Fix as_dict deprecation warnings by deleting it.

### DIFF
--- a/src/napari_matplotlib/base.py
+++ b/src/napari_matplotlib/base.py
@@ -42,7 +42,7 @@ class BaseNapariMPLWidget(QWidget):
         super().__init__(parent=parent)
         self.viewer = napari_viewer
         self.napari_theme_style_sheet = style_sheet_from_theme(
-            get_theme(napari_viewer.theme, as_dict=False)
+            get_theme(napari_viewer.theme)
         )
 
         # Sets figure.* style
@@ -84,7 +84,7 @@ class BaseNapariMPLWidget(QWidget):
             Event that triggered the callback.
         """
         self.napari_theme_style_sheet = style_sheet_from_theme(
-            get_theme(event.value, as_dict=False)
+            get_theme(event.value)
         )
         self._replace_toolbar_icons()
 
@@ -97,7 +97,7 @@ class BaseNapariMPLWidget(QWidget):
         bool
             True if theme's background colour has hsl lighter than 50%, False if darker.
         """
-        theme = napari.utils.theme.get_theme(self.viewer.theme, as_dict=False)
+        theme = napari.utils.theme.get_theme(self.viewer.theme)
         _, _, bg_lightness = theme.background.as_hsl_tuple()
         return bg_lightness > 0.5
 

--- a/src/napari_matplotlib/tests/test_theme.py
+++ b/src/napari_matplotlib/tests/test_theme.py
@@ -29,7 +29,7 @@ def _mock_up_theme() -> None:
     Based on:
     https://napari.org/stable/gallery/new_theme.html
     """
-    blue_theme = napari.utils.theme.get_theme("dark", False)
+    blue_theme = napari.utils.theme.get_theme("dark")
     blue_theme.label = "blue"
     blue_theme.background = "#4169e1"  # my favourite shade of blue
     napari.utils.theme.register_theme(


### PR DESCRIPTION
Fixes `FutureWarning`s in Python 3.12.
```
E           FutureWarning: The `as_dict` kwarg has been deprecated since Napari 0.5.0 and will be removed in future version. You can use `get_theme(...).to_rgb_dict()`
```