### PR TITLE
Fix Labels object has no attribute rgb error

### DIFF
--- a/src/napari_matplotlib/histogram.py
+++ b/src/napari_matplotlib/histogram.py
@@ -99,15 +99,12 @@ class HistogramWidget(SingleAxesWidget):
         Called when the selected layers are updated.
         """
         super().on_update_layers()
-        if self._valid_layer_selection:
+        if self._valid_layer_selection and self.layers:
             self.layers[0].events.contrast_limits.connect(self._update_contrast_lims)
 
-        if not self.layers:
-            return
-
-        # Reset the num bins based on new layer data
-        layer_data = self._get_layer_data(self.layers[0])
-        self._set_widget_nums_bins(data=layer_data)
+            # Reset the num bins based on new layer data
+            layer_data = self._get_layer_data(self.layers[0])
+            self._set_widget_nums_bins(data=layer_data)
 
     def _update_contrast_lims(self) -> None:
         for lim, line in zip(

--- a/src/napari_matplotlib/tests/test_histogram.py
+++ b/src/napari_matplotlib/tests/test_histogram.py
@@ -164,3 +164,13 @@ def test_change_contrast(make_napari_viewer, astronaut_data):
     # update contrast limits of image layer, and check no errors are thrown
     image_layer = viewer.layers[0]
     image_layer.contrast_limits = [2, 50]
+
+
+def test_select_labels_layer(make_napari_viewer):
+    """Test that no errors are thrown when the Histogram widget
+    is opened with a labels layer selected."""
+    viewer = make_napari_viewer()
+    viewer.add_labels(np.ones(shape=(5, 5, 5), dtype="uint8"))
+
+    widget = HistogramWidget(viewer)
+    viewer.window.add_dock_widget(widget)


### PR DESCRIPTION
Closes https://github.com/matplotlib/napari-matplotlib/issues/313

Showing a HistogramWidget, then selecting an invalid layer type (e.g. Labels / Points / Shape...) was throwing `object has no attribute rgb error`. This was due to the bin number reset happening on every new layer selection (rather than just the valid ones).

This small fix should ensure this only happens for `Image` layers. I also added a corresponding test.